### PR TITLE
Use Date.getUTCSeconds / setUTCSeconds instead of setSeconds etc

### DIFF
--- a/src/threading/GAThreading.ts
+++ b/src/threading/GAThreading.ts
@@ -35,7 +35,7 @@ module gameanalytics
             public static createTimedBlock(delayInSeconds:number = 0): TimedBlock
             {
                 var time:Date = new Date();
-                time.setSeconds(time.getSeconds() + delayInSeconds);
+                time.setUTCSeconds(time.getUTCSeconds() + delayInSeconds);
 
                 var timedBlock:TimedBlock = new TimedBlock(time);
                 return timedBlock;
@@ -44,7 +44,7 @@ module gameanalytics
             public static performTaskOnGAThread(taskBlock:() => void, delayInSeconds:number = 0): void
             {
                 var time:Date = new Date();
-                time.setSeconds(time.getSeconds() + delayInSeconds);
+                time.setUTCSeconds(time.getUTCSeconds() + delayInSeconds);
 
                 var timedBlock:TimedBlock = new TimedBlock(time);
                 timedBlock.block = taskBlock;
@@ -61,7 +61,7 @@ module gameanalytics
             public static scheduleTimer(interval:number, callback:() => void): number
             {
                 var time:Date = new Date();
-                time.setSeconds(time.getSeconds() + interval);
+                time.setUTCSeconds(time.getUTCSeconds() + interval);
 
                 var timedBlock:TimedBlock = new TimedBlock(time);
                 timedBlock.block = callback;


### PR DESCRIPTION
Date.setSeconds doesn't do what we want during the hour after the switch from DST to standard time.  For example, let's create a Date object right after the switch:

    x = new Date('2023-10-29T01:00:00Z')
    >> Date Sun Oct 29 2023 01:00:00 GMT+0000 (Greenwich Mean Time)
    x.getTime()
    >> 1698541200000

It indicates 1 AM in winter time.

Now let's call setSeconds(0), which we might think should be a no-op since the second value is already 0:

    x.setSeconds(0)
    >> 1698537600000
    x
    >> Date Sun Oct 29 2023 01:00:00 GMT+0100 (British Summer Time)
    x.getTime()
    >> 1698537600000
    1698537600000 - 1698541200000
    >> -3600000

Now it indicates 1 AM in summer time, which is one hour before 1 AM in winter time.  Comparing the millisecond timestamps also confirms that the Date object has been moved back by one hour.